### PR TITLE
FIX: allow dots in custom tp image names 

### DIFF
--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -91,7 +91,7 @@ const custom_tp_name = value => {
 
 const custom_tp_image = value => {
   if(!value) return undefined
-  if(!value.match(/^[-\w\/]+(:[-\w\.]+)?$/)) return 'Invalid image format'
+  if(!value.match(/^[-\w\/\.]+(:[-\w\.]+)?$/)) return 'Invalid image format'
   return undefined
 }
 


### PR DESCRIPTION
(e.g. 4234.dsfsdfsdf.sdf.dkr.ecr.ap-southeast.amazonaws.com/folder/image:tag-name)