### PR TITLE
ci(github): adjust commitlint

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,3 +1,3 @@
 COMMIT_MESSAGE_REGEX: >-
-  /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)!?(\([a-z ]+\))?(: )([^\n]+)(\n{1}?((\n{1}[^\n]+)+)?)?(\n{1}(\n{1}[^\n]+)+)?.*/
+  /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)!?(\([a-z \-\._]+\))?(: )([^\n]+)(\n{1}?((\n{1}[^\n]+)+)?)?(\n{1}(\n{1}[^\n]+)+)?.*/
 PR_TITLE_REGEX: /.*/


### PR DESCRIPTION
Allows underscores, spaces, and dashes in scope name
Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>