### PR TITLE
feat(form-string-array): allow forms to extract a single field from a…

### DIFF
--- a/src/components/form/Wrapper.js
+++ b/src/components/form/Wrapper.js
@@ -440,7 +440,22 @@ class FormWrapperInner extends React.Component {
         const linkedId = item.linked.linkedId
         const linkedComponentValue = dotty.get(formProps.values, linkedId)
 
+        let meetsVisibilityRequirement = false
+
         if (linkedComponentValue === item.linked.visibilityParameter) {
+          meetsVisibilityRequirement = true
+        }
+
+        // catch edge case where booleans are strings - not sure why this is happening
+        // TOOD: work out why in some cases:
+        //   * item.linked.visibilityParameter == "true"
+        //   * linkedComponentValue == true
+        // the two things match but because of === they do not pass the test above
+        if(item.linked.visibilityParameter === "true" && linkedComponentValue === true) {
+          meetsVisibilityRequirement = true
+        }
+
+        if (meetsVisibilityRequirement) {
           return (
             <FieldArray
               _ci={item.id}
@@ -500,7 +515,7 @@ class FormWrapperInner extends React.Component {
       false
 
     if(hidden) return null
-      
+
     // if the field includes a list, render a field array, otherwise render a normal field
     return item.list ? renderFieldArray(processedItem) : renderField(processedItem)
     

--- a/src/components/form/utils.js
+++ b/src/components/form/utils.js
@@ -52,6 +52,36 @@ const getInitialValues = (schema, initialValues) => {
         dotty.put(all, field.id, field.default)
       }
     }
+    // explode a list of strings back into an array of objects
+    // with the value set on the "extractField" prop of the list
+    // this is so we can still use the form list editor
+    // for a list of strings rather than list of objects
+    else if(field.list && field.list.extractField) {
+      const valueArray = existing.map(primitiveValue => {
+        return {
+          [field.list.extractField]: primitiveValue,
+        }
+      })
+      dotty.put(all, field.id, valueArray)
+      return all
+    }
+    return all
+  }, Object.assign({}, initialValues))
+}
+
+const processInitialValues = (schema, initialValues) => {
+  const flatSchema = flattenSchema(schema)
+  return flatSchema.reduce((all, field) => {
+    const existing = dotty.get(all, field.id)
+    if(field.list && field.list.extractField) {
+      const valueArray = existing.map(primitiveValue => {
+        return {
+          [field.list.extractField]: primitiveValue,
+        }
+      })
+      dotty.put(all, field.id, valueArray)
+      return all
+    }
     return all
   }, Object.assign({}, initialValues))
 }
@@ -68,6 +98,13 @@ const processValues = (schema, values) => {
       dotty.put(all, field.id, value)
       return all
     }
+    // we are extracting a single field from each object in the list
+    else if(field.list && field.list.extractField) {
+      const objectValues = dotty.get(all, field.id)
+      const valueArray = objectValues.map(obj => obj[field.list.extractField])
+      dotty.put(all, field.id, valueArray)
+      return all
+    }
     else {
       return all
     }
@@ -79,6 +116,7 @@ const utils = {
   flattenErrors,
   getComponent,
   getInitialValues,
+  processInitialValues,
   processValues,
 }
 

--- a/src/containers/deployment/DeploymentForm.js
+++ b/src/containers/deployment/DeploymentForm.js
@@ -42,6 +42,7 @@ const clearAccessControlResults = () => userActions.setAccessControlResults([])
       if(existingValues) {
         initialValues = JSON.parse(JSON.stringify(existingValues.desired_state))
         schema = deploymentForms[existingValues.deployment_type].forms[existingValues.deployment_version]
+        initialValues = formUtils.processInitialValues(schema, initialValues)
       }
     }
 


### PR DESCRIPTION
…n array of objects

Signed-off-by: Kai Davenport <kaiyadavenport@gmail.com>

closes [SXT-461](https://blockchaintp.atlassian.net/browse/SXT-461)

**IMPORTANT** depends on https://github.com/catenasys/sextant-api/pull/203 (merge at same time)

Add a `extractField` prop to list fields which will turn the submitted data into an array of strings (or whatever the fields type is) as opposed to an array of objects.

So - previously:

```js
list: {
      mainField: 'name',
      schema: [{
        id: 'name',
        title: 'Name',
        helperText: 'The name of the secret',
        component: 'text',
        validate: {
          type: 'string',
          methods: [
            ['required', 'Required'],
            ['matches', [`^[a-z]([-a-z0-9]*[a-z0-9])*$`], "a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"]
          ],
        },
      }],
      table: [{
        title: 'Name',
        name: 'name',
      }]
    }
```

would result in this data:

```js
[{
  name: "apples"
}]
```

now - we can use this config:


```js
list: {
      // this means we want an array of the `name` fields
      // NOT an array of objects each with a name field
      extractField: 'name',
      mainField: 'name',
      schema: [{
        id: 'name',
        title: 'Name',
        helperText: 'The name of the secret',
        component: 'text',
        validate: {
          type: 'string',
          methods: [
            ['required', 'Required'],
            ['matches', [`^[a-z]([-a-z0-9]*[a-z0-9])*$`], "a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"]
          ],
        },
      }],
      table: [{
        title: 'Name',
        name: 'name',
      }]
    }
```

and it will result in this data:

```js
[
  "apples"
]
```