### PR TITLE
feat(taekionkeys): hide the delete button because the middleware does…

### DIFF
--- a/src/pages/deployment/taekion/Keys.js
+++ b/src/pages/deployment/taekion/Keys.js
@@ -112,7 +112,7 @@ class TaekionKeys extends React.Component {
     const data = keys.map((key, index) => {
       return {
         id: key.id,
-        name: key.name,
+        name: key.label,
         fingerprint: key.fingerprint,
       }
     })
@@ -136,13 +136,15 @@ class TaekionKeys extends React.Component {
 
     const getActions = () => {
   
-      const buttons = [{
-        title: 'Delete',
-        icon: DeleteIcon,
-        handler: onDeleteItem,
-      }]
+      // const buttons = [{
+      //   title: 'Delete',
+      //   icon: DeleteIcon,
+      //   handler: onDeleteItem,
+      // }]
 
-      return buttons
+      // return buttons
+
+      return []
     }
  
     const hooks = {


### PR DESCRIPTION
… not delete keys

Signed-off-by: Kai Davenport <kaiyadavenport@gmail.com>

hide the delete button for taekion keys because the middleware does not have this feature