### PR TITLE
fix(submit-action): removes cannot define id of undefined error

### DIFF
--- a/src/store/modules/deployment.js
+++ b/src/store/modules/deployment.js
@@ -254,9 +254,12 @@ const sideEffects = {
       // eslint-disable-next-line no-unused-expressions
       typeof yamlInput === 'string' ? custom_yaml = yamlInput : custom_yaml = ''
     } else {
-      const deployment = getState().deployment.deployments.entities.deployment[id]
+      // unpack the current deployment off state
+      const deploymentsOnState = getState().deployment.deployments
+      const { entities } = deploymentsOnState
+      const currentDeployment = entities.deployment[id]
       // eslint-disable-next-line no-unused-expressions
-      typeof yamlInput === 'string' ? custom_yaml = yamlInput : custom_yaml = deployment.custom_yaml
+      typeof yamlInput === 'string' ? custom_yaml = yamlInput : custom_yaml = currentDeployment.custom_yaml
     }
 
     dispatch(customizationActions.clearYamlInput(0))


### PR DESCRIPTION
move the definition of deployment to the else scope where the deployment id is not new

sxt-501

Signed-off-by: Mikeala Sheldt <mikaela@blockchaintp.com>