### PR TITLE
Uses npm ci in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY ./package.json /app/frontend/package.json
 
 COPY ./package-lock.json /app/frontend/package-lock.json
 
-RUN npm install
+RUN npm ci
 
 COPY ./ /app/frontend
 

--- a/Dockerfile.multistage
+++ b/Dockerfile.multistage
@@ -10,7 +10,7 @@ COPY ./package.json /app/frontend/package.json
 
 COPY ./package-lock.json /app/frontend/package-lock.json
 
-RUN npm install
+RUN npm ci
 
 COPY ./ /app/frontend
 


### PR DESCRIPTION
- swaps out `npm install` for `npm ci` as `npm ci` is meant for deployment and CI

sxt-721