### PR TITLE
Fixes bug which allowed users to delete a cluster without validation

### DIFF
--- a/src/components/table/SimpleTableTripleDeleteDialog.js
+++ b/src/components/table/SimpleTableTripleDeleteDialog.js
@@ -29,7 +29,7 @@ class SimpleTableTripleDeleteDialog extends React.Component {
 
   render() {
     const {
-      open, onCancel, onConfirm, title, clusterName, resource, resourceType,
+      open, onCancel, onConfirm, title, resource, resourceType,
     } = this.props
     const { name, error } = this.state
     const text = resource ? getDialogDeleteText(resource.status) : ''
@@ -80,7 +80,7 @@ class SimpleTableTripleDeleteDialog extends React.Component {
             disabled={error}
             _ci="confirm"
             id="simpleTableDeleteConfirm"
-            onClick={() => validateAndConfirm(name, clusterName)}
+            onClick={() => validateAndConfirm(name, resourceName)}
             variant="contained"
             color="primary"
             autoFocus


### PR DESCRIPTION
- provides proper logic to validate cluster name in delete dialog and reset `error` prop if dialog is dismissed or validation fails
- passes more usable prop to triple delete via clusterTable