### PR TITLE
docs(mkdocs): lowercase site_name

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 ---
-site_name: Sextant
+site_name: sextant
 site_author: BTP
 theme:
   name: material


### PR DESCRIPTION
When using the mono repo plugin the url slug is taken from the site name in the imported MkDocs.yml file. This should be lowercase, but is currently capitalised.